### PR TITLE
Store last-opened state of the file in SessionStorage

### DIFF
--- a/src/script/design/Element.ts
+++ b/src/script/design/Element.ts
@@ -1,4 +1,6 @@
+import { Main } from "../main";
 import { IRect } from "../model/Model";
+import { HistoryManager } from "./HistoryManager";
 
 export class ElementView {
     public static createElement(
@@ -16,8 +18,11 @@ export class ElementView {
     }
     public static toggleVisibility(domObj: HTMLElement): HTMLElement {
         domObj.style.display = domObj.style.display === "none" ? "inline-block" : "none";
+        const url = document.location.search + document.location.hash;
+        HistoryManager.UpdateHistory(url, Main.viModel);
         return domObj;
     }
+
     public static setVisible(domObj: HTMLElement, visibility: boolean): HTMLElement {
         if (visibility) {
             if (domObj.style.display === "inline-block") {

--- a/src/script/design/Element.ts
+++ b/src/script/design/Element.ts
@@ -19,6 +19,7 @@ export class ElementView {
     public static toggleVisibility(domObj: HTMLElement): HTMLElement {
         domObj.style.display = domObj.style.display === "none" ? "inline-block" : "none";
         const url = document.location.search + document.location.hash;
+        // TODO(Pratheeksha): Look for a better location to update history
         HistoryManager.UpdateHistory(url, Main.viModel);
         return domObj;
     }

--- a/src/script/design/HistoryManager.ts
+++ b/src/script/design/HistoryManager.ts
@@ -7,9 +7,6 @@ export class HistoryManager {
         }
         const stateObj = { filePath: updatedPath, parsedContent };
         top.history.replaceState(stateObj, updatedPath, updatedPath);
-        if (document.referrer === "http://127.0.0.1:8081/results.html") {
-            sessionStorage.setItem(document.location.search, JSON.stringify(parsedContent));
-        }
     }
     private static queryHeader: string = "?q=";
     private static metadataFileName: string = "/metadata.json";

--- a/src/script/design/HistoryManager.ts
+++ b/src/script/design/HistoryManager.ts
@@ -9,9 +9,6 @@ export class HistoryManager {
         top.history.replaceState(stateObj, updatedPath, updatedPath);
         if (document.referrer === "http://127.0.0.1:8081/results.html") {
             sessionStorage.setItem(document.location.search, JSON.stringify(parsedContent));
-        } else {
-        sessionStorage.setItem(document.referrer.substring(document.referrer.indexOf("?")),
-                        JSON.stringify(parsedContent));
         }
     }
     private static queryHeader: string = "?q=";

--- a/src/script/design/HistoryManager.ts
+++ b/src/script/design/HistoryManager.ts
@@ -7,6 +7,12 @@ export class HistoryManager {
         }
         const stateObj = { filePath: updatedPath, parsedContent };
         top.history.replaceState(stateObj, updatedPath, updatedPath);
+        if (document.referrer === "http://127.0.0.1:8081/results.html") {
+            sessionStorage.setItem(document.location.search, JSON.stringify(parsedContent));
+        } else {
+        sessionStorage.setItem(document.referrer.substring(document.referrer.indexOf("?")),
+                        JSON.stringify(parsedContent));
+        }
     }
     private static queryHeader: string = "?q=";
     private static metadataFileName: string = "/metadata.json";

--- a/src/script/design/PageLabel.ts
+++ b/src/script/design/PageLabel.ts
@@ -1,6 +1,8 @@
+import { Main } from "../main";
 import { IRect } from "../model/Model";
 import { TabControl } from "../model/TabControl";
 import { ElementView } from "./Element";
+import { HistoryManager } from "./HistoryManager";
 
 export class PageLabel {
     public pageArr: HTMLElement[];
@@ -20,13 +22,11 @@ export class PageLabel {
     public selectPage(event, obj: PageLabel) {
         const owningTab: TabControl = obj.modelObj;
         const selectedPage: number = owningTab.visiblePage;
-        ElementView.setVisible(obj.page, true);
-        owningTab.visiblePage = owningTab.pageSelectorNameArr.indexOf(obj.pageSelectorName);
         for (let i = 0; i < owningTab.tabLength; i++) {
-            if (i !== owningTab.visiblePage) {
-                ElementView.setVisible(obj.pageArr[i], false);
-            }
+            ElementView.setVisible(obj.pageArr[i], false);
         }
+        owningTab.visiblePage = owningTab.pageSelectorNameArr.indexOf(obj.pageSelectorName);
+        ElementView.toggleVisibility(obj.page);
     }
     public deselectPage(event) {
         const btnDeselect: HTMLButtonElement = event.target;

--- a/src/script/design/TabControl.ts
+++ b/src/script/design/TabControl.ts
@@ -27,7 +27,7 @@ export class TabControlView extends ComponentView {
         for (let i = 0; i < obj.tabLength; i++) {
             componentElement = ElementView.addElement(componentElement, this.pageSelectorElemArr[i]);
         }
-        ElementView.toggleVisibility(this.diagramElemArr[0]);
+        ElementView.toggleVisibility(this.diagramElemArr[obj.visiblePage]);
         return componentElement;
     }
 }

--- a/src/script/finale.ts
+++ b/src/script/finale.ts
@@ -36,7 +36,7 @@ function GenerateDOMForModel(query: string) {
             finale.removeChild(finale.lastChild);
         }
         finale.appendChild(htmlDOM);
-        top.postMessage({ highlight: true, id: query.slice(3).trim() }, "*");
+        top.postMessage({ highlight: true, id: Main.viPath }, "*");
     }
 }
 

--- a/src/script/finale.ts
+++ b/src/script/finale.ts
@@ -1,19 +1,19 @@
+import { isNullOrUndefined } from "util";
 import { HistoryManager } from "./design/HistoryManager";
 import { InputHelper } from "./design/inputHelper";
 import { HelpProvider } from "./help/helpProvider";
+import { Main } from "./main";
 import { Model } from "./modelParser";
 import { PathHelper } from "./pathHelper";
 import { ViewFactory } from "./viewFactory";
-import { isNullOrUndefined } from "util";
-import { Main } from "./main";
 
 document.addEventListener("DOMContentLoaded", () => {
     if (isNullOrUndefined(sessionStorage.getItem(document.location.search))) {
         generateDocument(document.location.search);
         } else {
             Main.viModel = JSON.parse(sessionStorage.getItem(document.location.search));
-            LoadDOM(document.location.search);
-        } 
+            GenerateDOMForModel(document.location.search);
+        }
     document.onkeyup = (e) => {
         if (InputHelper.IsHelpKeyBinding(e)) {
             HelpProvider.toggleVisibility();
@@ -23,19 +23,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
 let originPath = "";
 
-function LoadDOM(query : string) {
+function GenerateDOMForModel(query: string) {
     const viewObj = new ViewFactory();
     const htmlDOM = viewObj.generate(Main.viModel);
     if (htmlDOM) {
         const url = document.location.search + document.location.hash;
+        // TODO:Look at removing UpdateHistroy from here as updating history from LoadFile() in main.ts might suffice.
         HistoryManager.UpdateHistory(url, Main.viModel);
         const finale = document.getElementById("divLog");
         while (finale.hasChildNodes()) {
             finale.removeChild(finale.lastChild);
         }
-    finale.appendChild(htmlDOM);
-    top.postMessage({ highlight: true, id: query.slice(3).trim() }, "*");
-    }                                 
+        finale.appendChild(htmlDOM);
+        top.postMessage({ highlight: true, id: query.slice(3).trim() }, "*");
+    }
 }
 
 function generateDocument(query: string) {
@@ -47,8 +48,7 @@ function generateDocument(query: string) {
                 if (xhr.status === 200) {
                     if (xhr.responseText) {
                         Main.viModel = Model.parseJSON(xhr, originPath);
-                        //sessionStorage.setItem(document.location.search.slice(4), JSON.stringify(parsedContent));
-                        LoadDOM(query);
+                        GenerateDOMForModel(query);
                     }
                 } else {
                     alert("Invalid json file: " + query);

--- a/src/script/finale.ts
+++ b/src/script/finale.ts
@@ -4,9 +4,15 @@ import { HelpProvider } from "./help/helpProvider";
 import { Model } from "./modelParser";
 import { PathHelper } from "./pathHelper";
 import { ViewFactory } from "./viewFactory";
+import { isNullOrUndefined } from "util";
 
 document.addEventListener("DOMContentLoaded", () => {
-    generateDocument(document.location.search);
+    if (isNullOrUndefined(sessionStorage.getItem(document.location.search.slice(4)))) {
+        generateDocument(document.location.search);
+        } else {
+            parsedContent = JSON.parse(sessionStorage.getItem(document.location.search.slice(4)));
+            LoadDOM(document.location.search);
+        } 
     document.onkeyup = (e) => {
         if (InputHelper.IsHelpKeyBinding(e)) {
             HelpProvider.toggleVisibility();
@@ -14,7 +20,24 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 }, false);
 
+let parsedContent = null;
 let originPath = "";
+
+function LoadDOM(query : string) {
+    const viewObj = new ViewFactory();
+    const htmlDOM = viewObj.generate(parsedContent);
+    if (htmlDOM) {
+        const url = document.location.search + document.location.hash;
+        HistoryManager.UpdateHistory(url, parsedContent);
+        const finale = document.getElementById("divLog");
+        while (finale.hasChildNodes()) {
+            finale.removeChild(finale.lastChild);
+        }
+    finale.appendChild(htmlDOM);
+    top.postMessage({ highlight: true, id: query.slice(3).trim() }, "*");
+    }                                 
+}
+
 function generateDocument(query: string) {
     if (query && query.slice(0, 3) === "?q=") {
         originPath = PathHelper.getMetadataFilePath(query.slice(3).trim());
@@ -23,19 +46,9 @@ function generateDocument(query: string) {
             if (xhr.readyState === 4) {
                 if (xhr.status === 200) {
                     if (xhr.responseText) {
-                        const parsedContent = Model.parseJSON(xhr, originPath);
-                        const viewObj = new ViewFactory();
-                        const htmlDOM = viewObj.generate(parsedContent);
-                        if (htmlDOM) {
-                            const url = document.location.search + document.location.hash;
-                            HistoryManager.UpdateHistory(url, parsedContent);
-                            const finale = document.getElementById("divLog");
-                            while (finale.hasChildNodes()) {
-                                finale.removeChild(finale.lastChild);
-                            }
-                            finale.appendChild(htmlDOM);
-                            top.postMessage({ highlight: true, id: query.slice(3).trim() }, "*");
-                        }
+                        parsedContent = Model.parseJSON(xhr, originPath);
+                        sessionStorage.setItem(document.location.search.slice(4), JSON.stringify(parsedContent));
+                        LoadDOM(query);
                     }
                 } else {
                     alert("Invalid json file: " + query);

--- a/src/script/finale.ts
+++ b/src/script/finale.ts
@@ -5,12 +5,13 @@ import { Model } from "./modelParser";
 import { PathHelper } from "./pathHelper";
 import { ViewFactory } from "./viewFactory";
 import { isNullOrUndefined } from "util";
+import { Main } from "./main";
 
 document.addEventListener("DOMContentLoaded", () => {
-    if (isNullOrUndefined(sessionStorage.getItem(document.location.search.slice(4)))) {
+    if (isNullOrUndefined(sessionStorage.getItem(document.location.search))) {
         generateDocument(document.location.search);
         } else {
-            parsedContent = JSON.parse(sessionStorage.getItem(document.location.search.slice(4)));
+            Main.viModel = JSON.parse(sessionStorage.getItem(document.location.search));
             LoadDOM(document.location.search);
         } 
     document.onkeyup = (e) => {
@@ -20,15 +21,14 @@ document.addEventListener("DOMContentLoaded", () => {
     };
 }, false);
 
-let parsedContent = null;
 let originPath = "";
 
 function LoadDOM(query : string) {
     const viewObj = new ViewFactory();
-    const htmlDOM = viewObj.generate(parsedContent);
+    const htmlDOM = viewObj.generate(Main.viModel);
     if (htmlDOM) {
         const url = document.location.search + document.location.hash;
-        HistoryManager.UpdateHistory(url, parsedContent);
+        HistoryManager.UpdateHistory(url, Main.viModel);
         const finale = document.getElementById("divLog");
         while (finale.hasChildNodes()) {
             finale.removeChild(finale.lastChild);
@@ -46,8 +46,8 @@ function generateDocument(query: string) {
             if (xhr.readyState === 4) {
                 if (xhr.status === 200) {
                     if (xhr.responseText) {
-                        parsedContent = Model.parseJSON(xhr, originPath);
-                        sessionStorage.setItem(document.location.search.slice(4), JSON.stringify(parsedContent));
+                        Main.viModel = Model.parseJSON(xhr, originPath);
+                        //sessionStorage.setItem(document.location.search.slice(4), JSON.stringify(parsedContent));
                         LoadDOM(query);
                     }
                 } else {

--- a/src/script/finale.ts
+++ b/src/script/finale.ts
@@ -11,7 +11,8 @@ document.addEventListener("DOMContentLoaded", () => {
     if (isNullOrUndefined(sessionStorage.getItem(document.location.search))) {
         generateDocument(document.location.search);
         } else {
-            Main.viModel = JSON.parse(sessionStorage.getItem(document.location.search));
+            document.location.hash = JSON.parse(sessionStorage.getItem(document.location.search)).hashValue;
+            Main.viModel = JSON.parse(sessionStorage.getItem(document.location.search)).sourceModel;
             GenerateDOMForModel(document.location.search);
         }
     document.onkeyup = (e) => {

--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -8,9 +8,11 @@ export class Main {
         const currentState = top.history.state;
         const search = "?q=" + filePath;
         if (currentState !== null) {
-            const bdDiv: HTMLElement = document.getElementById("BlockDiagram");
+
             const stateObj = {hashValue: currentState.filePath.split("#")[1], sourceModel: currentState.parsedContent};
             sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
+
+            const bdDiv: HTMLElement = document.getElementById("BlockDiagram");
             if (bdDiv != null) {
                 currentState.xPos = bdDiv.scrollLeft;
                 currentState.yPos = bdDiv.scrollTop;

--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -11,14 +11,10 @@ export class Main {
         if (currentState !== null) {
             /* As few file models(like LVClass/ PolyVi) donot have # values.
             So, we store a empty string instead of an undefined value.*/
-            if (isNullOrUndefined(currentState.filePath.split("#")[1])) {
-                const stateObj = {hashValue: "", sourceModel: currentState.parsedContent};
-                sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
-            } else {
-                const stateObj = {hashValue: currentState.filePath.split("#")[1],
-                                  sourceModel: currentState.parsedContent};
-                sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
-            }
+            const hash = isNullOrUndefined(currentState.filePath.split("#")[1]) ?
+                                                "" : currentState.filePath.split("#")[1];
+            const stateObj = {hashValue : hash, sourceModel : currentState.parsedContent};
+            sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
 
             const bdDiv: HTMLElement = document.getElementById("BlockDiagram");
             if (bdDiv != null) {

--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -9,8 +9,8 @@ export class Main {
         const currentState = top.history.state;
         const search = "?q=" + filePath;
         if (currentState !== null) {
-            /* As few file models(like LVClass/ PolyVi) donot have # values.
-            So, we store a empty string instead of an undefined value.*/
+            /* As a few file types (like LVClass/ PolyVI) do not have # values,
+            we store an empty string in the session storage instead of storing an undefined value. */
             const hash = isNullOrUndefined(currentState.filePath.split("#")[1]) ?
                                                 "" : currentState.filePath.split("#")[1];
             const stateObj = {hashValue : hash, sourceModel : currentState.parsedContent};

--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -1,3 +1,5 @@
+import { stat } from "fs";
+
 export class Main {
     public static viPath;
     public static viModel;
@@ -7,7 +9,8 @@ export class Main {
         const search = "?q=" + filePath;
         if (currentState !== null) {
             const bdDiv: HTMLElement = document.getElementById("BlockDiagram");
-            sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(currentState.parsedContent));
+            const stateObj = {hashValue: currentState.filePath.split("#")[1], sourceModel: currentState.parsedContent};
+            sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
             if (bdDiv != null) {
                 currentState.xPos = bdDiv.scrollLeft;
                 currentState.yPos = bdDiv.scrollTop;

--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -1,4 +1,5 @@
 import { stat } from "fs";
+import { isNullOrUndefined } from "util";
 
 export class Main {
     public static viPath;
@@ -8,9 +9,17 @@ export class Main {
         const currentState = top.history.state;
         const search = "?q=" + filePath;
         if (currentState !== null) {
-
-            const stateObj = {hashValue: currentState.filePath.split("#")[1], sourceModel: currentState.parsedContent};
-            sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
+            /* As few file models(like LVClass/ PolyVi) donot have # values.
+            So, the #value for them in session storage is set as empty string.
+            Otherwise, it gets automatically assigned to undefined.*/
+            if (isNullOrUndefined(currentState.filePath.split("#")[1])) {
+                const stateObj = {hashValue: "", sourceModel: currentState.parsedContent};
+                sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
+            } else {
+                const stateObj = {hashValue: currentState.filePath.split("#")[1],
+                                  sourceModel: currentState.parsedContent};
+                sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));
+            }
 
             const bdDiv: HTMLElement = document.getElementById("BlockDiagram");
             if (bdDiv != null) {

--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -10,8 +10,7 @@ export class Main {
         const search = "?q=" + filePath;
         if (currentState !== null) {
             /* As few file models(like LVClass/ PolyVi) donot have # values.
-            So, the #value for them in session storage is set as empty string.
-            Otherwise, it gets automatically assigned to undefined.*/
+            So, we store a empty string instead of an undefined value.*/
             if (isNullOrUndefined(currentState.filePath.split("#")[1])) {
                 const stateObj = {hashValue: "", sourceModel: currentState.parsedContent};
                 sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(stateObj));

--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -1,11 +1,13 @@
 export class Main {
     public static viPath;
+    public static viModel;
 
     public static LoadFile(filePath: string) {
-        const currentState = history.state;
+        const currentState = top.history.state;
         const search = "?q=" + filePath;
         if (currentState !== null) {
             const bdDiv: HTMLElement = document.getElementById("BlockDiagram");
+            sessionStorage.setItem(currentState.filePath.split("#")[0], JSON.stringify(currentState.parsedContent));
             if (bdDiv != null) {
                 currentState.xPos = bdDiv.scrollLeft;
                 currentState.yPos = bdDiv.scrollTop;


### PR DESCRIPTION
In this feature, we aim to store the state of the last open editor for each file.
Web Storage(session storage) has been used to do it because:
i. It automatically deletes itself if a the tab is closed.
ii. No leakage of session storage info to another tabs in the same domain/host.
So, using web storage we store the #value and sourceModel of the file. So, when a user revisits the file, we retrieve back the saved data from the session storage and render the same state to the user.