### PR TITLE
Opening a subVI will show the project item in the files pane

### DIFF
--- a/src/script/main.ts
+++ b/src/script/main.ts
@@ -27,8 +27,9 @@ export class Main {
 top.addEventListener("DOMContentLoaded", () => {
     if (document.location.search && top.frames.length === 3) {
         Main.RedirectFinale(document.location.search);
-        top.onmessage = (e) => {
-            top.frames[1].postMessage(e.data, "*");
-        };
     }
 });
+
+top.onmessage = (e) => {
+    top.frames[1].postMessage(e.data, "*");
+};

--- a/src/script/treeView/lib/aimaratree.ts
+++ b/src/script/treeView/lib/aimaratree.ts
@@ -1,3 +1,4 @@
+// This code is based on aimaraJS - Pure Javascript TreeView Component (https://github.com/rafaelthca/aimaraJS)
 import { Main } from "../../main";
 import { Node } from "./node";
 
@@ -432,7 +433,7 @@ export class TreeHelper {
         return parentObj;
     }
 
-    public getTreeAndCallDblEvent(treeType) {
+    public getTreeAndExpandTopLevel(treeType) {
             const searchTree = document.getElementById(treeType).getElementsByClassName("tree");
             const lastElement = searchTree[0].getElementsByClassName("last");
             const spanElement = lastElement[0].getElementsByTagName("span");
@@ -458,7 +459,7 @@ export class TreeHelper {
             );
             rootNode = this.populateTree(newTree, searchNode, topDirectory.Components);
             newTree.drawTree();
-            this.getTreeAndCallDblEvent("filteredTree");
+            this.getTreeAndExpandTopLevel("filteredTree");
         } else {
             let icon = "";
             if (topDirectory.Type === "dir") {

--- a/src/script/treeView/lib/aimaratree.ts
+++ b/src/script/treeView/lib/aimaratree.ts
@@ -1,4 +1,4 @@
-// This code is based on aimaraJS - Pure Javascript TreeView Component (https://github.com/rafaelthca/aimaraJS)
+// This code is based on aimaraJS - Pure Javascript TreeView Component (https://github.com/rafaelthca/aimaraJS).
 import { Main } from "../../main";
 import { Node } from "./node";
 

--- a/src/script/treeView/lib/aimaratree.ts
+++ b/src/script/treeView/lib/aimaratree.ts
@@ -1,5 +1,3 @@
-// This code is based on aimaraJS - Pure Javascript TreeView Component (https://github.com/rafaelthca/aimaraJS).
-
 import { Main } from "../../main";
 import { Node } from "./node";
 
@@ -240,6 +238,7 @@ export class TreeHelper {
         }
 
         const vLI: HTMLLIElement = document.createElement("li");
+        vLI.id = pNode.path;
         pNode.elementLi = vLI;
 
         const vSpan: HTMLSpanElement = this.createSimpleElement("span", null, "node");
@@ -258,7 +257,7 @@ export class TreeHelper {
         }
         const currElement = this;
         const lazyLoad = () => {
-            const vUL: HTMLElement = currElement.createSimpleElement("ul", path, path);
+            const vUL: HTMLElement = currElement.createSimpleElement("ul", "", "");
             vLI.appendChild(vUL);
             if (pNode.childNodes.length > 0) {
                 if (!pNode.expanded) {
@@ -433,7 +432,7 @@ export class TreeHelper {
         return parentObj;
     }
 
-    public givenTreeExpandAtTopLevel(treeType) {
+    public getTreeAndCallDblEvent(treeType) {
             const searchTree = document.getElementById(treeType).getElementsByClassName("tree");
             const lastElement = searchTree[0].getElementsByClassName("last");
             const spanElement = lastElement[0].getElementsByTagName("span");
@@ -442,7 +441,6 @@ export class TreeHelper {
             // simulate double click event at the first level of the tree
             spanElement[0].dispatchEvent(evt);
     }
-
     // create tree view
     public directoryTreeView(topDirectory) {
         let rootNode = null;
@@ -460,7 +458,7 @@ export class TreeHelper {
             );
             rootNode = this.populateTree(newTree, searchNode, topDirectory.Components);
             newTree.drawTree();
-            this.givenTreeExpandAtTopLevel("filteredTree");
+            this.getTreeAndCallDblEvent("filteredTree");
         } else {
             let icon = "";
             if (topDirectory.Type === "dir") {

--- a/src/script/treeView/lib/wrapper.ts
+++ b/src/script/treeView/lib/wrapper.ts
@@ -117,7 +117,7 @@ function focusGivenNode(focusNode) {
         focusNode.className = "node_selected";
     }
 }
-function expandUpwardTree(jsonPath) {
+function createSubTreeAndExpandBranchForPath(jsonPath) {
     const jsonPathList = jsonPath.split("/");
     const partialPathsList = [""];
     for (let i = 1; i < jsonPathList.length - 1; i++) {
@@ -137,39 +137,44 @@ function expandUpwardTree(jsonPath) {
     focusGivenNode(selectedNode);
 }
 
+function expandBranchForPath(focusNode) {
+    let focusNodeTemp = focusNode;
+    const focusNodeSpan = focusNodeTemp.getElementsByTagName("span")[0];
+    while (focusNodeTemp.parentNode.parentNode !== null) {
+        const parentSpanElement = focusNodeTemp.parentElement.previousElementSibling;
+        const parentImageElement = parentSpanElement.previousElementSibling;
+        if (parentImageElement.id !== "toggle_off") {
+            const evt = new Event("dblclick");
+            parentSpanElement.dispatchEvent(evt);
+        } else {
+            focusGivenNode(focusNodeSpan);
+            break;
+        }
+        focusNodeTemp = focusNodeTemp.parentNode.parentElement;
+    }
+    focusNode.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" });
+}
+
 export function toggleSelectedNode(jsonPath) {
     const decodedJsonPath = decodeURIComponent(jsonPath);
     if (decodedJsonPath.split("/").pop() === "control") {
         document.getElementsByClassName("node_selected")[0].className = "node";
     } else {
         const focusNode = document.getElementById(decodedJsonPath);
-        let focusNodeTemp = focusNode;
-        /* If the tree strcuture for the file that we request is not expanded then,
-        we expand it first. Then, we highlight(node_selected) the file in the file-pane.
-        Else, we just do the node selection in the file pane for the requested file,
-        as the file tree is already open */
-        if (focusNodeTemp == null) {
-            expandUpwardTree(decodedJsonPath);
-        } else if (focusNodeTemp.getElementsByTagName("span")[0].className !== "node_selected") {
-            const focusNodeSpan = focusNodeTemp.getElementsByTagName("span")[0];
-            while (focusNodeTemp.parentNode.parentNode !== null) {
-                const parentSpanElement = focusNodeTemp.parentElement.previousElementSibling;
-                const parentImageElement = parentSpanElement.previousElementSibling;
-                if (parentImageElement.id !== "toggle_off") {
-                    const evt = new Event("dblclick");
-                    parentSpanElement.dispatchEvent(evt);
-                } else {
-                    focusGivenNode(focusNodeSpan);
-                    break;
-                }
-                focusNodeTemp = focusNodeTemp.parentNode.parentElement;
-            }
-            focusNode.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" });
+        /* If the requested node is not created we create the sub tree and and expand it the along the path.
+        Then, we perform focusNode() to highlight(set "node_selected") for the desired file.
+        Else the collapsed tree is expaned and then,
+        focusNode() is performed to highlight(set "node_selected") the the desired file.*/
+        if (focusNode == null) {
+            createSubTreeAndExpandBranchForPath(decodedJsonPath);
+        } else if (focusNode.getElementsByTagName("span")[0].className !== "node_selected") {
+            expandBranchForPath(focusNode);
         }
     }
     document.getElementById("filteredTree").style.display = "none";
     document.getElementById("divTree").style.display = "block";
 }
+
 export function openVI(viPath) {
     if (viPath) {
         Main.viPath = viPath;

--- a/src/script/treeView/lib/wrapper.ts
+++ b/src/script/treeView/lib/wrapper.ts
@@ -35,7 +35,7 @@ function loadFile() {
 
                 // Rendering the tree
                 tree.drawTree();
-                tree.getTreeAndCallDblEvent("divTree");
+                tree.getTreeAndExpandTopLevel("divTree");
                 const getParams = window.location.href.split(/=|#/);
                 if (getParams.length >= 2) {
                     const fixedStr = decodeURIComponent(getParams[1]);
@@ -117,15 +117,13 @@ function focusGivenNode(focusNode) {
         focusNode.className = "node_selected";
     }
 }
-function expandUpwardTree(decodedJsonPath) {
-    const pathList = decodedJsonPath.split("/");
-    // tslint:disable-next-line:prefer-const
-    let pathPlaceHolder = [""];
-    // tslint:disable-next-line:prefer-for-of
-    for (let i = 1; i < pathList.length - 1; i++) {
-        pathPlaceHolder[pathPlaceHolder.length] = pathList[i];
-        const pathPlaceHolderString = pathPlaceHolder.join("/");
-        const ulElement = document.getElementById(pathPlaceHolderString);
+function expandUpwardTree(jsonPath) {
+    const jsonPathList = jsonPath.split("/");
+    const partialPath = [""];
+    for (let i = 1; i < jsonPathList.length - 1; i++) {
+        partialPath[partialPath.length] = jsonPathList[i];
+        const jsonTreePathString = partialPath.join("/");
+        const ulElement = document.getElementById(jsonTreePathString);
         const img = ulElement.firstElementChild;
         const spanElement = img.nextSibling;
         if (img.id !== "toggle_off") {
@@ -133,7 +131,7 @@ function expandUpwardTree(decodedJsonPath) {
             spanElement.dispatchEvent(evt);
         }
     }
-    const selectNodeParent = document.getElementById(decodeURI(decodedJsonPath));
+    const selectNodeParent = document.getElementById(jsonPath);
     const selectedNode = selectNodeParent.getElementsByTagName("span")[0];
     selectedNode.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "start" });
     focusGivenNode(selectedNode);
@@ -146,8 +144,12 @@ export function toggleSelectedNode(jsonPath) {
     } else {
         const focusNode = document.getElementById(decodedJsonPath);
         let focusNodeTemp = focusNode;
+        /* If the tree strcuture for the file that we request is not expanded then,
+        we expand it first. Then, we highlight(node_selected) the file in the file-pane.
+        Else, we just do the node selection in the file pane for the requested file,
+        as the file tree is already open */
         if (focusNodeTemp == null) {
-            expandUpwardTree(jsonPath);
+            expandUpwardTree(decodedJsonPath);
         } else if (focusNodeTemp.getElementsByTagName("span")[0].className !== "node_selected") {
             const focusNodeSpan = focusNodeTemp.getElementsByTagName("span")[0];
             while (focusNodeTemp.parentNode.parentNode !== null) {

--- a/src/script/treeView/lib/wrapper.ts
+++ b/src/script/treeView/lib/wrapper.ts
@@ -119,11 +119,11 @@ function focusGivenNode(focusNode) {
 }
 function expandUpwardTree(jsonPath) {
     const jsonPathList = jsonPath.split("/");
-    const partialPath = [""];
+    const partialPathsList = [""];
     for (let i = 1; i < jsonPathList.length - 1; i++) {
-        partialPath[partialPath.length] = jsonPathList[i];
-        const jsonTreePathString = partialPath.join("/");
-        const ulElement = document.getElementById(jsonTreePathString);
+        partialPathsList[partialPathsList.length] = jsonPathList[i];
+        const partialPath = partialPathsList.join("/");
+        const ulElement = document.getElementById(partialPath);
         const img = ulElement.firstElementChild;
         const spanElement = img.nextSibling;
         if (img.id !== "toggle_off") {


### PR DESCRIPTION
When a subVI is opened the file explorer/ file pane does not reflect it. So in this feature we want the file pane to highlight the subVI location. 

So, there can be two cases:-
1. If the node corresponding to the path is not created
- We create the sub-tree for the file path and expand the tree along the path
- We use focusNode() to unset the previous VI selection and then set the current subVI as the selected VI.
2. If the node has already been created
- We expand the tree if it is collapsed.
- Then we use focusNode() to unset the previous VI selection and then set the current subVI as the selected VI.

Note: The entry point is window.onLoad() in wrapper.ts in order to understand the the workflow.