### PR TITLE
Fix file pane highlight on subVI navigation

### DIFF
--- a/src/script/finale.ts
+++ b/src/script/finale.ts
@@ -36,7 +36,7 @@ function GenerateDOMForModel(query: string) {
             finale.removeChild(finale.lastChild);
         }
         finale.appendChild(htmlDOM);
-        top.postMessage({ highlight: true, id: Main.viPath }, "*");
+        top.postMessage({ highlight: true, id: query.slice(3).trim() }, "*");
     }
 }
 

--- a/src/script/treeView/lib/wrapper.ts
+++ b/src/script/treeView/lib/wrapper.ts
@@ -113,9 +113,12 @@ function updateTreeViewAndSearchResults(searchStr: string) {
 }
 function focusGivenNode(focusNode) {
     if (focusNode.className !== "node_selected") {
-        document.getElementsByClassName("node_selected")[0].className = "node";
-        focusNode.className = "node_selected";
+        const selectedNode = document.getElementsByClassName("node_selected")[0];
+        if (selectedNode) {
+            selectedNode.className = "node";
+        }
     }
+    focusNode.className = "node_selected";
 }
 function createSubTreeAndExpandBranchForPath(jsonPath) {
     const jsonPathList = jsonPath.split("/");


### PR DESCRIPTION
There was a tiny bug in #11
`Main.viPath` was being sent as the path of the node that needed to be highlighted. This was an empty string and hence would end up not highlighting the required node on the files tree.
>> Changing it to the original code which sent the query (containing the required path) to highlight the required node on the files tree.

Additionally, if no node was highlighted originally, new nodes would not get highlighted either. For example, if we try to open a URL that has a query path specified, results.html would have created the tree without any node highlighted. And highlight would not work because the code first tries to deselect a selected node before selecting the new node.
>> Added a null check for this.

Also changed `GenerateDOMForModel` to camelCase.