### PR TITLE
Get converter script to accept cmd line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Follow these instructions to run FINALE:
 
       - On cmd or PowerShell, navigate to "<Path/to/FINALE/repo>/build/HTMLGenerator".
       - Run command:
-      > `python -c "import converter; converter.convert_from_JSON(<Absolute/path/to/JSON/file>)"`
+      > `python converter.py <path to JSON file>"`
       - The JSON file mentioned above should be of the structure:
         ```json
           {
@@ -97,8 +97,7 @@ Follow these instructions to run FINALE:
                 "inputPath": "...",
                 "outputPath": "...",
                 "preloadFiles": "..."
-              },
-              ...
+              }
             ]
           }
         ```

--- a/src/HTMLGenerator/converter.py
+++ b/src/HTMLGenerator/converter.py
@@ -85,7 +85,7 @@ def convert_from_JSON(jsonFilePath) :
         with open(jsonFilePath) as jsonFile:
             json_with_filepaths = json.load(jsonFile)
             write_configuration_file_and_run_converter(json_with_filepaths)
-    except FileNotFoundError as e:
+    except Exception as e:
         print (e)
 
 if __name__ == "__main__":

--- a/src/HTMLGenerator/converter.py
+++ b/src/HTMLGenerator/converter.py
@@ -4,6 +4,7 @@ import subprocess
 import pathlib
 from pathlib import Path
 import json
+import sys
 
 CURRENT_CONFIGURATION_PATH = "currentConfiguration.txt"
 NOTIFICATION_PATH = "complete.txt"
@@ -80,6 +81,34 @@ def run_converter(path_to_current_working_directory = Path.cwd()):
     return
 
 def convert_from_JSON(jsonFilePath) :
-    with open(jsonFilePath) as jsonFile:
-        json_with_filepaths = json.load(jsonFile)
-        write_configuration_file_and_run_converter(json_with_filepaths)
+    try:
+        with open(jsonFilePath) as jsonFile:
+            json_with_filepaths = json.load(jsonFile)
+            write_configuration_file_and_run_converter(json_with_filepaths)
+    except FileNotFoundError as e:
+        print (e)
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print ("Missing argument!")
+        print ("Usage: py converter.py <path to JSON file>")
+        print ("\n\nThe JSON should be of the form:")
+        print ("""
+{
+    "topPath": "Absolute path where you want the FINALE format to be stored",
+    "configurations": [
+        {
+            "inputPath": "Absolute path of the source files/directory that needs to be converted",
+            "outputPath": "Relative path to `topPath` so that the output of the converter can be redirected to this path instead of the `topPath`",
+            "preloadFiles": "File/Project that needs to be preloaded to load up the actual files that need to be converted"
+        },
+        {
+            "inputPath": "...",
+            "outputPath": "...",
+            "preloadFiles": "..."
+        }
+    ]
+}
+        """)
+    else:
+        convert_from_JSON(sys.argv[1])

--- a/src/HTMLGenerator/converter.py
+++ b/src/HTMLGenerator/converter.py
@@ -88,12 +88,11 @@ def convert_from_JSON(jsonFilePath) :
     except Exception as e:
         print (e)
 
-if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print ("Missing argument!")
-        print ("Usage: py converter.py <path to JSON file>")
-        print ("\n\nThe JSON should be of the form:")
-        print ("""
+def _print_usage_instructions():
+    print ("Missing argument!")
+    print ("Usage: python converter.py <path to JSON file>")
+    print ("\n\nThe JSON should be of the form:")
+    print ("""
 {
     "topPath": "Absolute path where you want the FINALE format to be stored",
     "configurations": [
@@ -109,6 +108,11 @@ if __name__ == "__main__":
         }
     ]
 }
-        """)
+    """)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        _print_usage_instructions()
     else:
         convert_from_JSON(sys.argv[1])


### PR DESCRIPTION
1. Make the converter script runnable through `__main__`.
1. Add usage instructions for the converter.
1. Add error handling for invalid file paths.
1. Update README.